### PR TITLE
Do not clobber default register when initializing tree buffers and do not fix window width when re-using working buffer windows

### DIFF
--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -1080,7 +1080,10 @@ function! easytree#OpenTree(win, dir)
         return
     endif
     call s:OpenEasyTreeWindow(a:win)
-    setlocal filetype=easytree buftype=nofile bufhidden=wipe nobuflisted noswapfile nowrap nonumber winfixwidth
+    setlocal filetype=easytree buftype=nofile bufhidden=wipe nobuflisted noswapfile nowrap nonumber
+    if a:win !~ "edit here"
+        setlocal winfixwidth
+    endif
     if g:easytree_show_line_numbers
         setlocal number
     endif


### PR DESCRIPTION
- Fix issue https://github.com/troydm/easytree.vim/issues/7 by using the "black hole" register when clearing the tree buffer.
- When using '`EasyTreeHere`', the window width is no longer adjustable due to the '`set local winfixedwidth`' command being issue in the buffer window. This fixes it by only fixing window width if EasyTree is opened in its own split.
