### PR TITLE
Allow configuring relativenumber in EasyTree

### DIFF
--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -1133,11 +1133,17 @@ function! easytree#OpenTree(win, dir)
     endif
     call s:OpenEasyTreeWindow(a:win)
     setlocal filetype=easytree buftype=nofile bufhidden=wipe nolist nobuflisted noswapfile nowrap nonumber
+    if exists('+relativenumber')
+        setlocal norelativenumber
+    endif
     if a:win !~ "edit here"
         setlocal winfixwidth
     endif
     if g:easytree_show_line_numbers
         setlocal number
+    endif
+    if g:easytree_show_relative_line_numbers
+        setlocal relativenumber
     endif
     if g:easytree_highlight_cursor_line
         setlocal cursorline

--- a/doc/easytree.txt
+++ b/doc/easytree.txt
@@ -51,6 +51,11 @@ g:easytree_cascade_open_single_dir     (Default: 1)
                                                          *g:easytree_show_line_numbers*
 g:easytree_show_line_numbers     (Default: 0)
     Show line numbers in easytree buffer
+
+                                                         *g:easytree_show_relative_line_numbers*
+g:easytree_show_relative_line_numbers     (Default: 0)
+    Show relative line numbers in easytree buffer
+
                                                          *g:easytree_show_hidden_files*
 g:easytree_show_hidden_files     (Default: 0)
     Show hidden files when opening new easytree buffer

--- a/plugin/easytree.vim
+++ b/plugin/easytree.vim
@@ -43,6 +43,10 @@ if !exists("g:easytree_show_line_numbers")
     let g:easytree_show_line_numbers = 0
 endif
 
+if !exists("g:easytree_show_relative_line_numbers")
+    let g:easytree_show_relative_line_numbers = 0
+endif
+
 if !exists("g:easytree_show_hidden_files")
     let g:easytree_show_hidden_files = 0
 endif


### PR DESCRIPTION
This commit adds the ability for the user to specify whether relative line numbering should be turned on in EasyTree windows. By default it is disabled (with a feature guard as it is a relatively new Vim feature), mirroring EasyTree's handling of standard line numbering. It can be enabled by setting

```viml
let g:easytree_show_relative_line_numbers = 1
```