### PR TITLE
Added function MoveFiles()

### DIFF
--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -352,6 +352,23 @@ function! s:CopyFilesRange() range
     endif
 endfunction
 
+function! s:MoveFiles(linen)
+    if s:AskConfirmation('are you sure you want to move the files here?')
+        let fpath = s:GetFullPath(a:linen)
+        let files = s:GetPasteBuffer()
+
+        python easytree.EasyTreeCopyFiles()
+        call s:Refresh(a:linen)
+
+        let messages = pyeval('easytree.EasyTreeRemoveFiles()')
+        call s:Refresh(s:GetParentLvlLinen(a:linen))
+
+        for m in messages
+            echom m
+        endfor
+    endif
+endfunction
+
 function! s:EchoPasteBuffer()
     let files = s:GetPasteBuffer()
     if len(files) > 0
@@ -1186,6 +1203,7 @@ function! easytree#OpenTree(win, dir)
     nnoremap <silent> <buffer> C :call <SID>ChangeDir(line('.'))<CR>
     nnoremap <silent> <buffer> c :call <SID>RenameFile(line('.'))<CR>
     nnoremap <silent> <buffer> cd :call <SID>ChangeCwdDir(line('.'))<CR>
+    nnoremap <silent> <buffer> <m-m> :call <SID>MoveFiles(line('.'))<CR>
     nnoremap <silent> <buffer> m :call <SID>CreateFile(line('.'))<CR>
     nnoremap <silent> <buffer> r :call <SID>Refresh(line('.'))<CR>
     nnoremap <silent> <buffer> R :call <SID>RefreshAll()<CR>

--- a/doc/easytree.txt
+++ b/doc/easytree.txt
@@ -163,6 +163,8 @@ g:easytree_width_auto_fit   (Default: 0)
         just move your cursor over the directory you want to paste your files/dirs into and press |p|  
         Same way to delete file/dir just move your cursor over that file/dir press |dd|
         To delete multiple files/dirs just select them in visual mode and press |d|
+        To move files/dirs copy them via yy/y. Then move your cursor over the
+        directory you want to move them and press <m-m> (Alt + m).
     Tree settings management:
         To save tree settings press |K|
         To load tree settings press |L|

--- a/doc/easytree.txt
+++ b/doc/easytree.txt
@@ -164,7 +164,7 @@ g:easytree_width_auto_fit   (Default: 0)
         Same way to delete file/dir just move your cursor over that file/dir press |dd|
         To delete multiple files/dirs just select them in visual mode and press |d|
         To move files/dirs copy them via yy/y. Then move your cursor over the
-        directory you want to move them and press <m-m> (Alt + m).
+        directory you want to put them in and press <m-m> (Alt + m).
     Tree settings management:
         To save tree settings press |K|
         To load tree settings press |L|


### PR DESCRIPTION
I have to move files on a frequent basis. Hitting `yy`, moving in the tree, hitting `p`, moving back where I did the `yy` and pressing `dd` is a little cumbersome.

I've implemented a quick solution so the `copy/paste` buffer can also be used as a `cut/paste` buffer via `<m-m>` and you don't have to go back and delete the files you wanted to move.

Not sure about the mapping though. I like `m` for **m**ove, but as it's already taken by CreateFile (see issue #16) I've added a temporary mapping to `<m-m>`.