### PR TITLE
Stopping MoveFiles if empty paste buffer

### DIFF
--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -357,6 +357,10 @@ function! s:CopyFilesRange() range
 endfunction
 
 function! s:MoveFiles(linen)
+    if len(s:GetPasteBuffer()) < 1
+        echom "no files selected for moving"
+        return
+    endif
     echo 'paste buffer:'
     for f in s:GetPasteBuffer()
         echo f

--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -358,7 +358,7 @@ endfunction
 
 function! s:MoveFiles(linen)
     if len(s:GetPasteBuffer()) < 1
-        echom "no files selected for moving"
+        echom 'no files selected for moving'
         return
     endif
     echo 'paste buffer:'


### PR DESCRIPTION
If the paste buffer is empty the MoveFiles command will fail.
But before it fails the user has to enter y/n.

This improves the UX as the outcome of the input is not depending on the input  - moving will stop :)