### PR TITLE
MoveFiles: pasting via GetFullPathDir instead of GetFullPath

### DIFF
--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -362,7 +362,7 @@ function! s:MoveFiles(linen)
         echo f
     endfor
     if s:AskConfirmation('are you sure you want to move the files here?')
-        let fpath = s:GetFullPath(a:linen)
+        let fpath = s:GetFullPathDir(a:linen)
         let files = s:GetPasteBuffer()
 
         let error = pyeval('easytree.EasyTreeCopyFiles()')

--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -379,7 +379,7 @@ function! s:MoveFiles(linen)
         endif
 
         call pyeval('easytree.EasyTreeRemoveFiles()')
-        call s:Refresh(s:GetParentLvlLinen(a:linen))
+        call s:RefreshAll()
         if len(files) == 0 && len(error) == 0
             echom 'No files were moved'
             return


### PR DESCRIPTION
It's more convenient to be able to paste files into the parent directory when triggering MoveFiles on a file in the wanted directory.
 
What do you think?