### PR TITLE
Convert to Python 3

### DIFF
--- a/autoload/easytree.py
+++ b/autoload/easytree.py
@@ -27,7 +27,7 @@ def EasyTreeFind(pattern,dir,showhidden):
         pattern = '*'+pattern+'*'
     ignore_find_result = vim.eval('b:ignore_find_result')
     filelist = EasyTreeList(dir,showhidden, lambda f: fnmatch.fnmatch(f,pattern))
-    filelist = filter(lambda f: not EasyTreeFnmatchList(f,ignore_find_result), filelist)
+    filelist = [f for f in filelist if not EasyTreeFnmatchList(f,ignore_find_result)]
     return filelist
 
 def EasyTreeList(dir,showhidden,findfilter):
@@ -43,17 +43,17 @@ def EasyTreeList(dir,showhidden,findfilter):
         if not showhidden:
             if root.startswith('.') or os.sep+'.' in root:
                 continue
-            dirs = filter(lambda d: not d.startswith("."),dirs)
-            files = filter(lambda f: not f.startswith("."),files)
+            dirs = [d for d in dirs if not d.startswith(".")]
+            files = [f for f in files if not f.startswith(".")]
         if len(root) > 0:
             if EasyTreeFnmatchList(root,ignore_dirs):
                 continue
-            dirs = map(lambda d: root+os.sep+d,dirs)
-            files = map(lambda f: root+os.sep+f,files)
-        dirs = filter(findfilter, dirs)
-        files = filter(findfilter, files)
-        dirs = filter(lambda d: not EasyTreeFnmatchList(d,ignore_dirs), dirs)
-        files = filter(lambda f: not EasyTreeFnmatchList(f,ignore_files), files)
+            dirs = [root+os.sep+d for d in dirs]
+            files = [root+os.sep+f for f in files]
+        dirs = list(filter(findfilter, dirs))
+        files = list(filter(findfilter, files))
+        dirs = [d for d in dirs if not EasyTreeFnmatchList(d,ignore_dirs)]
+        files = [f for f in files if not EasyTreeFnmatchList(f,ignore_files)]
         dirs = sorted(dirs)
         files = sorted(files)
         filelist.extend(dirs)
@@ -66,10 +66,10 @@ def EasyTreeListDir(dir,showhidden):
     ignore_files = vim.eval('b:ignore_files')
     for root, dirs, files in os.walk(dir):
         if int(showhidden) == 0:
-            dirs = filter(lambda d: not d.startswith("."),dirs)
-            files = filter(lambda f: not f.startswith("."),files)
-        dirs = filter(lambda d: not EasyTreeFnmatchList(d,ignore_dirs), dirs)
-        files = filter(lambda f: not EasyTreeFnmatchList(f,ignore_files), files)
+            dirs = [d for d in dirs if not d.startswith(".")]
+            files = [f for f in files if not f.startswith(".")]
+        dirs = [d for d in dirs if not EasyTreeFnmatchList(d,ignore_dirs)]
+        files = [f for f in files if not EasyTreeFnmatchList(f,ignore_files)]
         dirs = sorted(dirs)
         files = sorted(files)
         return [root, dirs, files]
@@ -117,10 +117,10 @@ def EasyTreeCopyFileTree(src, dst):
     rdirs = [dst]
     rfiles = []
     for root, dirs, files in os.walk(src):
-        rdirs.extend(map(lambda d: dst+root[len(src):]+os.path.sep+d, dirs))
-        rfiles.extend(map(lambda f: (root+os.path.sep+f,dst+root[len(src):]+os.path.sep+f), files))
-    map(os.makedirs,rdirs)
-    map(lambda (s,d): shutil.copyfile(s,d),rfiles)
+        rdirs.extend([dst+root[len(src):]+os.path.sep+d for d in dirs])
+        rfiles.extend([(root+os.path.sep+f,dst+root[len(src):]+os.path.sep+f) for f in files])
+    list(map(os.makedirs,rdirs))
+    list(map(lambda s_d: shutil.copyfile(s_d[0],s_d[1]),rfiles))
 
 def EasyTreeCopyFiles():
     dpath = vim.eval('fpath')+os.sep
@@ -159,8 +159,8 @@ def EasyTreeCopyFiles():
                     try:
                         EasyTreeCopyFile(f,dst,overwrite)
                         i += 1
-                    except OSError, e:
-                        print str(repr(e))
+                    except OSError as e:
+                        print(str(repr(e)))
                         return "error"
                 else:
                     vim.command("echom 'can''t copy from same source to same destination'")
@@ -190,7 +190,7 @@ def EasyTreeRemoveFiles():
                 else:
                     os.remove(f)
                 i += 1
-            except OSError, e:
+            except OSError as e:
                 messages.append(str(repr(e)))
         else:
             messages.append(f+" doesn't exists")

--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -25,7 +25,7 @@ endif
 " }}}
 
 " load python module {{{
-python << EOF
+python3 << EOF
 import vim, os, random, sys
 easytree_path = vim.eval("expand('<sfile>:h')")
 if not easytree_path in sys.path:
@@ -427,7 +427,7 @@ function! s:PasteFiles(linen)
             echo f
         endfor
         if s:AskConfirmation('are you sure you want to paste '.filesm.'?')
-            python easytree.EasyTreeCopyFiles()
+            python3 easytree.EasyTreeCopyFiles()
             call s:Refresh(a:linen)
         endif
     endif
@@ -479,7 +479,7 @@ function! s:CreateFile(linen)
     let path = s:AskInput('create '.fpath,'')
     if !empty(path)
         let path = fpath.path
-        python easytree.EasyTreeCreateFile()
+        python3 easytree.EasyTreeCreateFile()
         call s:Refresh(a:linen)
     endif
 endfunction
@@ -493,7 +493,7 @@ function! s:RenameFile(linen)
         if !s:DeleteBuf(fpath)
             return
         endif
-        python easytree.EasyTreeRenameFile()
+        python3 easytree.EasyTreeRenameFile()
         call s:Refresh(s:GetParentLvlLinen(a:linen))
     endif
 endfunction
@@ -842,7 +842,7 @@ function! s:UnexpandDir(fpath,linen)
     else
         let linee -= 1
     endif
-    exe 'python vim.current.buffer['.linee.'] = None'
+    exe 'python3 vim.current.buffer['.linee.'] = None'
     call s:WidthAutoFit()
 endfunction
 
@@ -1036,7 +1036,7 @@ function! s:GetInfo(linen)
             echo 'name: '.info[0].'  owner: '.info[1].(info[2] == '' ? '' : ':'.info[2]).'  size: '.info[3].'  mode: '.info[4].'  last modified: '.info[5]
             if !py3eval('easytree.easytree_dirsize_calculator.isAlive()')
                 let info[3] = py3eval("easytree.EasyTreeGetSize(easytree.easytree_dirsize_calculator_curr_size)")
-                python easytree.easytree_dirsize_calculator = None
+                python3 easytree.easytree_dirsize_calculator = None
                 break
             endif
         endwhile

--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -35,7 +35,7 @@ import easytree
 EOF
 " }}}
 
-let s:easytree_on_windows = pyeval('easytree.easytree_on_windows')
+let s:easytree_on_windows = py3eval('easytree.easytree_on_windows')
 if s:easytree_on_windows
     let s:easytree_path_sep = '\'
 else
@@ -138,10 +138,10 @@ endfunction
 
 function! s:GetFullPathDir(linen)
     let fpath = s:GetFullPath(a:linen)
-    if pyeval("os.path.isdir(vim.eval('fpath'))")
+    if py3eval("os.path.isdir(vim.eval('fpath'))")
         return fpath
     else
-        let fpath = pyeval("os.path.dirname(vim.eval('fpath'))")
+        let fpath = py3eval("os.path.dirname(vim.eval('fpath'))")
         return fpath
     endif
 endfunction
@@ -150,7 +150,7 @@ function! s:GetFullPath(linen)
     if a:linen == 2
         let dirp = getline(1)
         if dirp != '/'
-            let dirp = pyeval("os.path.abspath(vim.eval('dirp')+'".s:easytree_path_sep."..')")
+            let dirp = py3eval("os.path.abspath(vim.eval('dirp')+'".s:easytree_path_sep."..')")
         endif
         return dirp
     elseif a:linen == 1
@@ -183,12 +183,12 @@ endfunction
 
 function! s:DirName(path)
     let path = a:path
-    return pyeval("os.path.dirname(vim.eval('path'))")
+    return py3eval("os.path.dirname(vim.eval('path'))")
 endfunction
 
 function! s:FileName(path)
     let path = a:path
-    return pyeval("os.path.basename(vim.eval('path'))")
+    return py3eval("os.path.basename(vim.eval('path'))")
 endfunction
 
 function! s:GetPasteBuffer()
@@ -300,7 +300,7 @@ function! s:ChangeDirTo(...)
         let path = s:AskInputComplete('go to ',getline(1),'dir')
     endif
     if !empty(path)
-        if pyeval("os.path.isdir(os.path.expanduser(vim.eval('path')))")
+        if py3eval("os.path.isdir(os.path.expanduser(vim.eval('path')))")
             call s:InitializeNewTree(path)
         else
             redraw
@@ -369,7 +369,7 @@ function! s:MoveFiles(linen)
         let fpath = s:GetFullPathDir(a:linen)
         let files = s:GetPasteBuffer()
 
-        let error = pyeval('easytree.EasyTreeCopyFiles()')
+        let error = py3eval('easytree.EasyTreeCopyFiles()')
         if type(error) == 1 && error == 'error'
             return
         endif
@@ -382,7 +382,7 @@ function! s:MoveFiles(linen)
             let files = s:GetPasteBuffer()
         endif
 
-        call pyeval('easytree.EasyTreeRemoveFiles()')
+        call py3eval('easytree.EasyTreeRemoveFiles()')
         call s:RefreshAll()
         if len(files) == 0 && len(error) == 0
             echom 'No files were moved'
@@ -439,7 +439,7 @@ function! s:RemoveFile(linen)
         let fpath = s:GetFullPath(a:linen)
         let files = [fpath]
         if s:DeleteBuf(fpath) && s:AskConfirmation('are you sure you want to delete this file?')
-            let messages = pyeval('easytree.EasyTreeRemoveFiles()')
+            let messages = py3eval('easytree.EasyTreeRemoveFiles()')
             call s:Refresh(s:GetParentLvlLinen(a:linen))
         endif
     endif
@@ -465,7 +465,7 @@ function! s:RemoveFiles() range
             echo f
         endfor
         if s:AskConfirmation('are you really sure you want to delete this files?')
-            let messages = pyeval('easytree.EasyTreeRemoveFiles()')
+            let messages = py3eval('easytree.EasyTreeRemoveFiles()')
             call s:RefreshAll()
         endif
     endif
@@ -587,7 +587,7 @@ function! s:Find(linen, find)
         let @/ = ''
         let b:find = find
         echo 'searching for '.find
-        exe "let b:findresult = pyeval(\"easytree.EasyTreeFind(vim.eval('find'),vim.eval('fpath'),".b:showhidden.")\")"
+        exe "let b:findresult = py3eval(\"easytree.EasyTreeFind(vim.eval('find'),vim.eval('fpath'),".b:showhidden.")\")"
         redraw
         if fpath != getline(1)
             let fpath = fpath[len(getline(1)):]
@@ -864,7 +864,7 @@ function! s:ExpandDir(fpath,linen)
     endif
     let lvl = s:GetLvl(getline(linen))
     let lvls = repeat('  ',lvl)
-    let treelist = pyeval("easytree.EasyTreeListDir(vim.eval('a:fpath'),".b:showhidden.")")
+    let treelist = py3eval("easytree.EasyTreeListDir(vim.eval('a:fpath'),".b:showhidden.")")
     let cascade = g:easytree_cascade_open_single_dir && len(treelist[1]) == 1 && len(treelist[2]) == 0
     for d in treelist[1]
         if g:easytree_use_plus_and_minus
@@ -892,7 +892,7 @@ function! s:InitializeTree(dir)
     setlocal modifiable
     let b:find = ''
     let b:findresult = []
-    let treelist = pyeval("easytree.EasyTreeListDir(vim.eval('a:dir'),".b:showhidden.")")
+    let treelist = py3eval("easytree.EasyTreeListDir(vim.eval('a:dir'),".b:showhidden.")")
     silent! normal! gg"_dG
     call setline(1, treelist[0])
     call append(1, '  .. (up a dir)')
@@ -1026,16 +1026,16 @@ endfunction
 
 function! s:GetInfo(linen)
     let fpath = s:GetFullPath(a:linen)
-    let info = pyeval('easytree.EasyTreeGetInfo()')
+    let info = py3eval('easytree.EasyTreeGetInfo()')
     echo 'name: '.info[0].'  owner: '.info[1].(info[2] == '' ? '' : ':'.info[2]).'  size: '.info[3].'  mode: '.info[4].'  last modified: '.info[5]
-    if pyeval('easytree.easytree_dirsize_calculator != None')
+    if py3eval('easytree.easytree_dirsize_calculator != None')
         while 1
             sleep 1
-            let info[3] = pyeval("easytree.EasyTreeGetSize(easytree.easytree_dirsize_calculator_curr_size)+(('.'*random.randint(1,3)).ljust(3))")
+            let info[3] = py3eval("easytree.EasyTreeGetSize(easytree.easytree_dirsize_calculator_curr_size)+(('.'*random.randint(1,3)).ljust(3))")
             redraw
             echo 'name: '.info[0].'  owner: '.info[1].(info[2] == '' ? '' : ':'.info[2]).'  size: '.info[3].'  mode: '.info[4].'  last modified: '.info[5]
-            if !pyeval('easytree.easytree_dirsize_calculator.isAlive()')
-                let info[3] = pyeval("easytree.EasyTreeGetSize(easytree.easytree_dirsize_calculator_curr_size)")
+            if !py3eval('easytree.easytree_dirsize_calculator.isAlive()')
+                let info[3] = py3eval("easytree.EasyTreeGetSize(easytree.easytree_dirsize_calculator_curr_size)")
                 python easytree.easytree_dirsize_calculator = None
                 break
             endif
@@ -1186,8 +1186,8 @@ function! easytree#OpenTree(win, dir)
     if empty(dir)
         let dir = getcwd()
     endif
-    let dir = pyeval("os.path.expanduser(vim.eval('dir'))")
-    if !pyeval("os.path.isdir(vim.eval('dir'))")
+    let dir = py3eval("os.path.expanduser(vim.eval('dir'))")
+    if !py3eval("os.path.isdir(vim.eval('dir'))")
         echo 'invalid path '.dir
         return
     endif

--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -1243,7 +1243,7 @@ function! easytree#OpenTree(win, dir)
     nnoremap <silent> <buffer> m :call <SID>CreateFile(line('.'))<CR>
     nnoremap <silent> <buffer> r :call <SID>Refresh(line('.'))<CR>
     nnoremap <silent> <buffer> R :call <SID>RefreshAll()<CR>
-    nnoremap <silent> <buffer> i :try \| call <SID>GetInfo(line('.')) \| finally \| exe 'py easytree.easytree_dirsize_calculator=None' \| endtry<CR>
+    nnoremap <silent> <buffer> i :try \| call <SID>GetInfo(line('.')) \| finally \| exe 'py3 easytree.easytree_dirsize_calculator=None' \| endtry<CR>
     nnoremap <silent> <buffer> I :call <SID>ToggleHidden()<CR>
     nnoremap <silent> <buffer> H :call <SID>ChangeDirTo(expand('~'))<CR>
     nnoremap <silent> <buffer> J :call <SID>ChangeDirTo()<CR>

--- a/plugin/easytree.vim
+++ b/plugin/easytree.vim
@@ -13,21 +13,14 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 " check python support and vim patchset version {{{
-if !has("python")
+if !has("python3_compiled")
     if exists("g:easytree_suppress_load_warning") && g:easytree_suppress_load_warning
         finish
     endif
-    echo "easytree needs vim compiled with +python option"
+    echo "easytree needs vim compiled with +python3 option"
     finish
 endif
 
-if !exists('*pyeval')
-    if exists("g:easytree_suppress_load_warning") && g:easytree_suppress_load_warning
-        finish
-    endif
-    echo "easytree needs vim 7.3 with atleast 569 patchset included"
-    finish
-endif
 " }}}
 
 " options {{{


### PR DESCRIPTION
Python 2 is EOL and is not included in Homebrew on macs, for example.

Changes:
- Ran the easytree.py through python's `2to3`
- Changed the init check to look for python 3 instead of 2
- Changed all references to `python` command to `python3`