### PR TITLE
Git symbols position

### DIFF
--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -122,7 +122,11 @@ for indicator in values(g:easytree_git_indicators)
 endfor
 
 function! s:GetFName(line)
-    return matchlist(a:line,'^[▸▾+\- ]\+\([^'.s:easytree_git_indicators_regexp.']\+\)\(\s['.s:easytree_git_indicators_regexp.']\+\)\?$')[1]
+    if g:easytree_git_symbols_behind == 1
+        return matchlist(a:line,'^[▸▾+\- ]\+\([^'.s:easytree_git_indicators_regexp.']\+\)\(\s['.s:easytree_git_indicators_regexp.']\+\)\?$')[1]
+    else
+        return matchlist(a:line,'^[▸▾+\- ]\+\(['.s:easytree_git_indicators_regexp.']\+\)\?\s\(.\+\)$')[2]
+    endif
 endfunction
 
 function! s:GetParentLvlLinen(linen)
@@ -277,7 +281,11 @@ function! s:AddGitStatusIndicators(f,fullpath)
         for indicator in b:git[1][a:fullpath]
             let indicators = indicators.g:easytree_git_indicators[indicator]
         endfor
-        return a:f.' '.indicators
+        if g:easytree_git_symbols_behind == 1
+            return a:f.' '.indicators
+        else
+            return indicators.' '.a:f
+        endif
     else
         return a:f
     endif

--- a/doc/easytree.txt
+++ b/doc/easytree.txt
@@ -126,6 +126,10 @@ g:easytree_git_enable   (Default: 1)
 g:easytree_git_indicators
     Customize git status indicator icons
 
+                                                         *g:easytree_git_symbols_behind*
+g:easytree_git_symbols_behind (Default: 1)
+    Customize git symbols position
+
 ============================================================================================
  2. USAGE                                                         *easytree.vim-usage*
 

--- a/plugin/easytree.vim
+++ b/plugin/easytree.vim
@@ -93,6 +93,10 @@ if !exists("g:easytree_git_enable")
     let g:easytree_git_enable = 1
 endif
 
+if !exists("g:easytree_git_symbols_behind")
+    let g:easytree_git_symbols_behind = 1
+endif
+
 if !exists("g:easytree_git_indicators")
     let g:easytree_git_indicators = {
                     \ 'Branch'    : '',


### PR DESCRIPTION
Allow to customize git symbols position with `g:easytree_git_symbols_behind`:

✗✹ README 

or default:

README ✗✹ 

I prefer to find always git symbols before filename