### PR TITLE
Refresh Easytree and continue on same window

### DIFF
--- a/autoload/easytree.vim
+++ b/autoload/easytree.vim
@@ -1239,13 +1239,26 @@ function! easytree#ToggleTree(win, dir)
     endif
 endfunction
 
+function! easytree#RefreshAll()
+    let initial_winnr = winnr()
+    if easytree#OpenTreeFocus() == 1
+        call s:RefreshAll()
+    endif
+    if initial_winnr != winnr()
+        exe string(initial_winnr).'wincmd w'
+    endif
+endfunction
+
 function! easytree#OpenTreeFocus()
+    let result = 0
     let wnrs = filter(range(1,winnr('$')),"getbufvar(winbufnr(v:val),'&filetype') == 'easytree'")
     if len(wnrs) > 0
         exe string(wnrs[0]).'wincmd w'
+        let result = 1
     else
         echo 'No EasyTree windows are open'
     endif
+    return result
 endfunction
 
 function! easytree#OpenTreeReveal(file)

--- a/plugin/easytree.vim
+++ b/plugin/easytree.vim
@@ -133,6 +133,7 @@ command! -nargs=0 EasyTreeBufferTopDouble call easytree#OpenTree('top double',fn
 command! -nargs=0 EasyTreeBufferBottomDouble call easytree#OpenTree('bottom double',fnamemodify(bufname(),':p:h'))
 command! -nargs=0 EasyTreeBufferReveal call easytree#OpenTreeReveal(fnamemodify(bufname(),':p'))
 command! -nargs=0 EasyTreeFocus call easytree#OpenTreeFocus()
+command! -nargs=0 EasyTreeRefreshAll call easytree#RefreshAll()
 " }}}
 
 " netrw hijacking related functions {{{


### PR DESCRIPTION
Allow to refresh Easytree from current file.

This start the option to connect autocommands like buffferwritepost to update automatically.

Probably avoid redraw or keep same currrent line visible (if easytree is scrolled) needs to be controlled fo smooth execution